### PR TITLE
fix: remove rent field and its controllers

### DIFF
--- a/controllers/carController.js
+++ b/controllers/carController.js
@@ -57,12 +57,12 @@ const deleteCar = async (req, res) => {
 
 const editCar = async (req, res) => {
 	try {
-		if (!req.body._id || !req.body.name || !req.body.price || !req.body.model || !req.body.rent) {
+		if (!req.body._id || !req.body.name || !req.body.price || !req.body.model ) {
 			res.status(400).json({ message: "Bad request. Missing required fields" });
 			return;
 		}
 		const _id = req.body._id;
-		const { name, type, price, model, rent } = req.body;
+		const { name, type, price, model } = req.body;
 		const carToEdit = await Car.findById(_id);
 		if (!carToEdit) {
 			res.status(404).json({ message: "Car does not exist" });
@@ -72,8 +72,7 @@ const editCar = async (req, res) => {
             name,
             type,
             price,
-            model,
-			rent
+            model
         });
         res.status(200).json({ message: 'User updated successfully' });
 	} catch (err) {

--- a/controllers/rentController.js
+++ b/controllers/rentController.js
@@ -43,14 +43,6 @@ const createRent = async (req, res) => {
 		const newRent = await Rent.create(rentData)
 		const savedRentData = await newRent.save()
 
-		//save rent id to its car
-		car.rent.push(savedRentData._id)
-		await car.save()
-
-		//save rent id to its user
-		customer.rent.push(savedRentData._id)
-		await customer.save()
-
 		res.status(201).json({ message: "Rent created successfully", rent: savedRentData })
 	} catch (err) {
 		console.error(err)
@@ -72,26 +64,6 @@ const deleteRent = async (req, res) => {
 		if (!rentToDelete) {
 			res.status(404).json({ message: "Rent does not exist" });
 			return;
-		}
-
-		//delete rent id from its car
-		const car = await Car.findById(rentToDelete.carID)
-		if (car) {
-			const index = car.rent.indexOf(rentToDelete._id);
-			if (index > -1) { // only splice array when item is found
-				car.rent.splice(index, 1); // 2nd parameter means remove one item only
-			}
-			await car.save();
-		}
-
-		//delete rent id from its user
-		const customer = await User.findById(rentToDelete.customerID)
-		if (customer) {
-			const index = customer.rent.indexOf(rentToDelete._id);
-			if (index > -1) { // only splice array when item is found
-				customer.rent.splice(index, 1); // 2nd parameter means remove one item only
-			}
-			await customer.save();
 		}
 
 		//delete rent

--- a/models/carModel.js
+++ b/models/carModel.js
@@ -17,8 +17,7 @@ const carSchema = Schema({
     model: {
         type: String,
         required: true
-    },
-    rent: []
+    }
 });
 
 const carModel = models.Car || model('car', carSchema);

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -6,7 +6,6 @@ const userSchema = Schema({
     email: { type: String, required: true },
     password: { type: String, required: true },
     telp: { type: String, required: true },
-    rent: [],
     createdAt: { type: Date, default: Date.now(), required: true },
     updatedAt: { type: Date, default: Date.now(), required: true }
 });


### PR DESCRIPTION
Here are the things that I remove:
1. Remove rent field in car model
2. Remove rent field in user model
3. Remove "push rent id to car" function
4. Remove "pop rent id from car" function
5. Remove "push rent id to user" function
6. Remove "pop rent id from user" function

Here are the reasons why I remove them:
1. Remove redundancy between car, user, and rent.
2. Avoid asynchrony between car, user, and rent.