### PR TITLE
fix: change car getById route

### DIFF
--- a/controllers/carController.js
+++ b/controllers/carController.js
@@ -13,21 +13,21 @@ const getAllCar = async (req, res) => {
 	}
 };
 
-const getCarById = async (req,res) => {
+const getCarById = async (req, res) => {
 	try {
-        const _id = req.params.id;
-        const car = await Car.findById(_id);
+		const _id = req.params.id;
+		const car = await Car.findById(_id);
 
-        // handle null car
-        if (!car) {
-            res.status(404).json({ error: 'Car not found' });
-            return;
-        }
+		// handle null car
+		if (!car) {
+			res.status(404).json({ error: 'Car not found' });
+			return;
+		}
 
-        res.status(200).json({ car: car });
-    } catch (err) {
-        res.status(500).json({ error: err });
-    }
+		res.status(200).json({ car });
+	} catch (err) {
+		res.status(500).json({ error: err });
+	}
 }
 
 const createCar = async (req, res) => {

--- a/routes/carRoute.js
+++ b/routes/carRoute.js
@@ -5,7 +5,7 @@ const carController = require("../controllers/carController");
 const authToken = require("../middleware/authToken");
 
 router.get("/all", carController.getAllCar);
-router.get("/:id", carController.getCarById);
+router.get("/id/:id", carController.getCarById);
 router.post("/create", authToken, carController.createCar);
 router.delete("/delete", carController.deleteCar);
 router.put("/edit", carController.editCar);


### PR DESCRIPTION
This is done because there was an error when fetching /api/car/search and /api/car/searchAvailableCar. This is because /api/car/:id has been implemented to fetch car by id, thus "search" and "searchAvailableCar" is perceived to be :id. Changing /api/car/:id to /api/car/id/:id solves this issue