### PR TITLE
fix: fix api/car/search issue

### DIFF
--- a/controllers/carController.js
+++ b/controllers/carController.js
@@ -119,8 +119,6 @@ const searchCar = async (req, res) => {
 		var { model, type, transmission, maxPrice, minPrice, order, sortBy } = req.query;
 		var filter = {};
 
-		transmission = transmission.split(",");
-
 		// make a filter consisting of every inputted query 
 		if (model) {
 			filter = { ...filter, model }
@@ -129,6 +127,7 @@ const searchCar = async (req, res) => {
 			filter = { ...filter, type }
 		}
 		if (transmission) {
+			transmission = transmission.split(",");
 			filter = { ...filter, transmission }
 		}
 


### PR DESCRIPTION
/api/car/search should retrieve all car. But, it threw error instead. It happened because transmission tried to be split even if transmission was undefined. Setting up a conditional for the existence of transmission solves this issue.